### PR TITLE
fix esm build filename in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "npm": ">=5"
   },
   "main": "dist/index.js",
-  "module": "react-async-hook.esm.js",
+  "module": "dist/react-async-hook.esm.js",
   "typings": "dist/index.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
Previously, the package.json point to a file in the **root** package dir, that not exists, the correct file is in dist dir