### PR TITLE
Generate a stable options object post-normalization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -240,7 +240,7 @@ const useAsyncInternal = <R = UnknownResult, Args extends any[] = UnknownArgs>(
   const normalizedOptions = normalizeOptions<R>(options);
 
   // Use memoization to produce a stable options object post-normalization.
-  const memoizedOptions = useMemo(normalizedOptions, Object.values(normalizedOptions));
+  const memoizedOptions = useMemo(() => normalizedOptions, Object.values(normalizedOptions));
 
   const [currentParams, setCurrentParams] = useState<Args | null>(null);
 


### PR DESCRIPTION
While trying to install one of the hooks in my project, I noticed that the `reset` function is not stable through renders. The root cause is that you call `normalizeOptions` and produce a new options object every render which totally defeats the purpose of wrapping `reset` in a `useCallback`.

This PR memoizes the options object (post-normalization) so `reset` is stable. Note that this will still produce unstable options if the user is passing an anonymous `initialState` or any other function, but at least it'll handle the common cases such as passing no options at all.