### PR TITLE
remove useCallbacks calls on useAsyncState

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -153,28 +153,18 @@ const useAsyncState = <R extends {}>(
     options,
   ]);
 
-  const setLoading = useCallback(() => setValue(options.setLoading(value)), [
-    value,
-    setValue,
-  ]);
-  const setResult = useCallback(
-    (result: R) => setValue(options.setResult(result, value)),
-    [value, setValue]
-  );
+  const setLoading = () => setValue(value => options.setLoading(value));
+  const setResult = (result: R) =>
+    setValue(value => options.setResult(result, value));
 
-  const setError = useCallback(
-    (error: Error) => setValue(options.setError(error, value)),
-    [value, setValue]
-  );
+  const setError = (error: Error) =>
+    setValue(value => options.setError(error, value));
 
-  const merge = useCallback(
-    (state: Partial<AsyncState<R>>) =>
-      setValue({
-        ...value,
-        ...state,
-      }),
-    [value, setValue]
-  );
+  const merge = (state: Partial<AsyncState<R>>) =>
+    setValue(value => ({
+      ...value,
+      ...state,
+    }));
 
   return {
     value,


### PR DESCRIPTION
from: https://reactjs.org/docs/hooks-reference.html#usestate 's Note.

React guarantees that `setState` function identity is stable and won’t change on re-renders. This is why it’s safe to omit from the `useEffect` or `useCallback` dependency list.